### PR TITLE
Use newest plugin when multiple versions are found

### DIFF
--- a/tfschema/client.go
+++ b/tfschema/client.go
@@ -63,12 +63,13 @@ func findPlugin(pluginType string, pluginName string) (*discovery.PluginMeta, er
 		return nil, err
 	}
 
-	pluginMetaSet := discovery.FindPlugins(pluginType, dirs)
+	pluginMetaSet := discovery.FindPlugins(pluginType, dirs).WithName(pluginName)
 
-	for plugin := range pluginMetaSet {
-		if plugin.Name == pluginName {
-			return &plugin, nil
-		}
+	// if pluginMetaSet doesn't have any pluginMeta, pluginMetaSet.Newest() will call panic.
+	// so check it here.
+	if pluginMetaSet.Count() > 0 {
+		ret := pluginMetaSet.Newest()
+		return &ret, nil
 	}
 
 	return nil, fmt.Errorf("Failed to find plugin: %s. Plugin binary was not found in any of the following directories: [%s]", pluginName, strings.Join(dirs, ", "))


### PR DESCRIPTION
This PR changes to always use newest plugin version when multiple versions found.

## background

If you have multiple plugin versions as follows:

```bash
$ ls -1 ~/.terraform.d/plugins/
terraform-provider-foobar_v1.0.0_x4
terraform-provider-foobar_v1.1.0_x4
```

tfschema uses foobar's `v1.0.0` or `v1.1.0` randomly.

The cause is in the following part.
https://github.com/minamijoyo/tfschema/blob/0980d8e264ae59d76e65cafec7188c68a440a62e/tfschema/client.go#L66-L72

`discovery.FindPlugins` returns `discovery.PluginMetaSet`. 
It is defined as `map[PluginMeta]struct{}`.
https://github.com/hashicorp/terraform/blob/v0.11.7/plugin/discovery/meta_set.go#L7
So its iteration order is not guaranteed.
