### PR TITLE
Change JSON output format for easy parsing

### DIFF
--- a/command/data_show.go
+++ b/command/data_show.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"flag"
-	"fmt"
 	"strings"
 
 	"github.com/minamijoyo/tfschema/tfschema"
@@ -51,17 +50,7 @@ func (c *DataShowCommand) Run(args []string) int {
 		return 1
 	}
 
-	var out string
-	switch c.format {
-	case "table":
-		out, err = block.FormatTable()
-	case "json":
-		out, err = block.FormatJSON()
-	default:
-		c.UI.Error(fmt.Sprintf("Unknown output format: %s", c.format))
-		c.UI.Error(c.Help())
-		return 1
-	}
+	out, err := formatBlock(block, c.format)
 
 	if err != nil {
 		c.UI.Error(err.Error())

--- a/command/meta.go
+++ b/command/meta.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/minamijoyo/tfschema/formatter"
+	"github.com/minamijoyo/tfschema/tfschema"
 	"github.com/mitchellh/cli"
 )
 
@@ -52,4 +54,13 @@ func buildDataDocURL(dataSource string) (string, error) {
 	// https://www.terraform.io/docs/providers/aws/d/security_group.html
 	url := docBaseURL + s[0] + "/d/" + s[1] + ".html"
 	return url, nil
+}
+
+// formatBlock is a helper function for formatting tfschema.Block.
+func formatBlock(b *tfschema.Block, format string) (string, error) {
+	f, err := formatter.NewBlockFormatter(b, format)
+	if err != nil {
+		return "", err
+	}
+	return f.Format()
 }

--- a/command/provider_show.go
+++ b/command/provider_show.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"flag"
-	"fmt"
 	"strings"
 
 	"github.com/minamijoyo/tfschema/tfschema"
@@ -45,17 +44,7 @@ func (c *ProviderShowCommand) Run(args []string) int {
 		return 1
 	}
 
-	var out string
-	switch c.format {
-	case "table":
-		out, err = block.FormatTable()
-	case "json":
-		out, err = block.FormatJSON()
-	default:
-		c.UI.Error(fmt.Sprintf("Unknown output format: %s", c.format))
-		c.UI.Error(c.Help())
-		return 1
-	}
+	out, err := formatBlock(block, c.format)
 
 	if err != nil {
 		c.UI.Error(err.Error())

--- a/command/resource_show.go
+++ b/command/resource_show.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"flag"
-	"fmt"
 	"strings"
 
 	"github.com/minamijoyo/tfschema/tfschema"
@@ -51,17 +50,7 @@ func (c *ResourceShowCommand) Run(args []string) int {
 		return 1
 	}
 
-	var out string
-	switch c.format {
-	case "table":
-		out, err = block.FormatTable()
-	case "json":
-		out, err = block.FormatJSON()
-	default:
-		c.UI.Error(fmt.Sprintf("Unknown output format: %s", c.format))
-		c.UI.Error(c.Help())
-		return 1
-	}
+	out, err := formatBlock(block, c.format)
 
 	if err != nil {
 		c.UI.Error(err.Error())

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -1,0 +1,31 @@
+package formatter
+
+import (
+	"fmt"
+
+	"github.com/minamijoyo/tfschema/formatter/json"
+	"github.com/minamijoyo/tfschema/formatter/table"
+	"github.com/minamijoyo/tfschema/tfschema"
+)
+
+// BlockFormatter is an interface of formatting Block.
+// This is an abstraction layer for separating data structure and output format.
+type BlockFormatter interface {
+	Format() (string, error)
+}
+
+// NewBlockFormatter is a factory method which returns a BlockFormatter interface.
+func NewBlockFormatter(b *tfschema.Block, format string) (BlockFormatter, error) {
+	var f BlockFormatter
+
+	switch format {
+	case "table":
+		f = table.NewBlock(b)
+	case "json":
+		f = json.NewBlock(b)
+	default:
+		return nil, fmt.Errorf("Failed to new BlockFormatter. Unknown output format: %s", format)
+	}
+
+	return f, nil
+}

--- a/formatter/json/attribute.go
+++ b/formatter/json/attribute.go
@@ -1,17 +1,22 @@
-package tfschema
+package json
 
-import (
-	"github.com/hashicorp/terraform/config/configschema"
-)
+import "github.com/minamijoyo/tfschema/tfschema"
 
-// Attribute is wrapper for configschema.Attribute.
+// Attribute is wrapper for tfschema.Attribute.
 type Attribute struct {
+	// Name is a name of attribute.
+	// Note that this key does not exist in the original data structure.
+	// In order to reduce the possibility of future conflicts,
+	// naming borrowed from the schema definition of the grpc provider's proto file.
+	// https://github.com/hashicorp/terraform/pull/18550
+	Name string `json:"name"`
+
 	// Type is a type of the attribute's value.
 	// Note that Type is not cty.Type
 	// We cannot import github.com/hashicorp/terraform/vendor/github.com/zclconf/go-cty/cty
 	// On the other hand, tfschema does not need a dynamic type.
-	// So, we use a simple representation of type defined in this package.
-	Type Type `json:"type"`
+	// So, we use a simple representation of type defined in tfschema package.
+	Type tfschema.Type `json:"type"`
 	// Required is a flag whether this attribute is required.
 	Required bool `json:"required"`
 	// Optional is a flag whether this attribute is optional.
@@ -27,9 +32,10 @@ type Attribute struct {
 }
 
 // NewAttribute creates a new Attribute instance.
-func NewAttribute(a *configschema.Attribute) *Attribute {
+func NewAttribute(a *tfschema.Attribute, name string) *Attribute {
 	return &Attribute{
-		Type:      *NewType(a.Type),
+		Name:      name,
+		Type:      a.Type,
 		Required:  a.Required,
 		Optional:  a.Optional,
 		Computed:  a.Computed,

--- a/formatter/json/block.go
+++ b/formatter/json/block.go
@@ -1,0 +1,76 @@
+package json
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/minamijoyo/tfschema/tfschema"
+)
+
+// Block is wrapper for tfschema.Block.
+// This is a layer for customization for JSON format.
+// Although the original data structure is a map,
+// it is hard to parse because the names of the key are not predictable.
+// We use a slice here to format easy-to-parse JSON.
+type Block struct {
+	// Attributes is a slice of any attributes.
+	Attributes []*Attribute `json:"attributes"`
+	// BlockTypes is a slice of any nested block types.
+	BlockTypes []*NestedBlock `json:"block_types"`
+}
+
+// NewBlock creates a new Block instance.
+func NewBlock(b *tfschema.Block) *Block {
+	return &Block{
+		Attributes: NewAttributes(b.Attributes),
+		BlockTypes: NewBlockTypes(b.BlockTypes),
+	}
+}
+
+// NewAttributes creates a new slice of Attributes.
+func NewAttributes(as map[string]*tfschema.Attribute) []*Attribute {
+	m := make([]*Attribute, 0)
+
+	// sort map keys
+	keys := []string{}
+	for k := range as {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		attr := NewAttribute(as[k], k)
+		m = append(m, attr)
+	}
+
+	return m
+}
+
+// NewBlockTypes creates a new slice of NestedBlocks.
+func NewBlockTypes(bs map[string]*tfschema.NestedBlock) []*NestedBlock {
+	m := make([]*NestedBlock, 0)
+
+	// sort map keys
+	keys := []string{}
+	for k := range bs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		nestedBlock := NewNestedBlock(bs[k], k)
+		m = append(m, nestedBlock)
+	}
+
+	return m
+}
+
+// Format returns a formatted string in JSON format.
+func (b *Block) Format() (string, error) {
+	bytes, err := json.MarshalIndent(b, "", "    ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(bytes), nil
+}

--- a/formatter/json/nested_block.go
+++ b/formatter/json/nested_block.go
@@ -1,0 +1,37 @@
+package json
+
+import (
+	"github.com/hashicorp/terraform/config/configschema"
+	"github.com/minamijoyo/tfschema/tfschema"
+)
+
+// NestedBlock is wrapper for tfschema.NestedBlock
+type NestedBlock struct {
+	// TypeName is a name of block type.
+	// Note that this key does not exist in the original data structure.
+	// In order to reduce the possibility of future conflicts,
+	// naming borrowed from the schema definition of the grpc provider's proto file.
+	// https://github.com/hashicorp/terraform/pull/18550
+	TypeName string `json:"type_name"`
+
+	// Block is a nested child block.
+	Block
+	// Nesting is a nesting mode.
+	Nesting configschema.NestingMode `json:"nesting"`
+	// MinItems is a lower limit on number of nested child blocks.
+	MinItems int `json:"min_items"`
+	// MaxItems is a upper limit on number of nested child blocks.
+	MaxItems int `json:"max_items"`
+}
+
+// NewNestedBlock creates a new NestedBlock instance.
+func NewNestedBlock(b *tfschema.NestedBlock, typeName string) *NestedBlock {
+	block := NewBlock(&b.Block)
+	return &NestedBlock{
+		TypeName: typeName,
+		Block:    *block,
+		Nesting:  b.Nesting,
+		MinItems: b.MinItems,
+		MaxItems: b.MaxItems,
+	}
+}

--- a/formatter/table/block.go
+++ b/formatter/table/block.go
@@ -1,0 +1,119 @@
+package table
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/minamijoyo/tfschema/tfschema"
+	"github.com/olekukonko/tablewriter"
+)
+
+// Block is wrapper for tfschema.Block.
+// This is a layer for customization for table format.
+type Block struct {
+	// Simply embedding the structure.
+	tfschema.Block
+}
+
+// NewBlock creates a new Block instance.
+func NewBlock(b *tfschema.Block) *Block {
+	return &Block{
+		Block: *b,
+	}
+}
+
+// Format returns a formatted string in table format.
+func (b *Block) Format() (string, error) {
+	return renderBlock(b)
+}
+
+// renderBlock returns a formatted string in table format for Block.
+func renderBlock(b *Block) (string, error) {
+	buf := new(bytes.Buffer)
+	attributes, err := renderAttributes(b)
+	if err != nil {
+		return "", err
+	}
+	buf.WriteString(attributes)
+
+	blockTypes, err := renderBlockTypes(b)
+	if err != nil {
+		return "", err
+	}
+	buf.WriteString(blockTypes)
+
+	return buf.String(), nil
+}
+
+// renderAttributes returns a formatted string in table format for Attributes.
+func renderAttributes(b *Block) (string, error) {
+	buf := new(bytes.Buffer)
+	table := tablewriter.NewWriter(buf)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+
+	table.SetHeader([]string{"attribute", "type", "required", "optional", "computed", "sensitive"})
+
+	// sort map keys
+	keys := []string{}
+	for k := range b.Attributes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := b.Attributes[k]
+		typeName, err := v.Type.Name()
+		if err != nil {
+			return "", err
+		}
+
+		row := []string{
+			k,
+			typeName,
+			strconv.FormatBool(v.Required),
+			strconv.FormatBool(v.Optional),
+			strconv.FormatBool(v.Computed),
+			strconv.FormatBool(v.Sensitive),
+		}
+		table.Append(row)
+	}
+
+	table.Render()
+
+	return buf.String(), nil
+}
+
+// renderBlockTypes returns a formatted string in table format for BlockTypes.
+func renderBlockTypes(b *Block) (string, error) {
+	if len(b.BlockTypes) == 0 {
+		return "", nil
+	}
+
+	buf := new(bytes.Buffer)
+
+	// sort map keys
+	keys := []string{}
+	for k := range b.BlockTypes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := b.BlockTypes[k]
+		blockType := fmt.Sprintf("\nblock_type: %s, nesting: %s, min_items: %d, max_items: %d\n", k, v.Nesting, v.MinItems, v.MaxItems)
+		buf.WriteString(blockType)
+
+		// We need *Block, not *tfschema.NestedBlock. Convert it here.
+		nested := NewBlock(&v.Block)
+		block, err := renderBlock(nested)
+		if err != nil {
+			return "", err
+		}
+
+		buf.WriteString(block)
+	}
+
+	return buf.String(), nil
+}

--- a/formatter/table/nested_block.go
+++ b/formatter/table/nested_block.go
@@ -1,0 +1,18 @@
+package table
+
+import (
+	"github.com/minamijoyo/tfschema/tfschema"
+)
+
+// NestedBlock is wrapper for tfschema.NestedBlock
+type NestedBlock struct {
+	// Simply embedding the structure.
+	tfschema.NestedBlock
+}
+
+// NewNestedBlock creates a new NestedBlock instance.
+func NewNestedBlock(b *tfschema.NestedBlock) *NestedBlock {
+	return &NestedBlock{
+		NestedBlock: *b,
+	}
+}


### PR DESCRIPTION
Fixes #4

The previous JSON output format depends on the named attributes and block_types. It's hard to parse. If we use a slice instead of a map, we can make the key name predictable. However, I don't want to change the internal data structure for the convenience of the only JSON format. I want to also use a tfschema as a Go library not only CLI. So, the data model of tfschema should be separated from the requirements of the output format.

Extract format related code from the `tfschema` package to a new `formatter` package, define a new type for output and call it from `command` package, and change the JSON output format.
In order to reduce the possibility of future conflicts, the name of keys are borrowed from the schema definition of the grpc provider's proto file.

## before

```
$ tfschema --version
0.1.2

$ tfschema resource show -format=json azurerm_virtual_network
{
    "attributes": {
        "address_space": {
            "type": "List(String)",
            "required": true,
            "optional": false,
            "computed": false,
            "sensitive": false
        },
        "dns_servers": {
            "type": "List(String)",
            "required": false,
            "optional": true,
            "computed": false,
            "sensitive": false
        },
        "location": {
            "type": "String",
            "required": true,
            "optional": false,
            "computed": false,
            "sensitive": false
        },
        "name": {
            "type": "String",
            "required": true,
            "optional": false,
            "computed": false,
            "sensitive": false
        },
        "resource_group_name": {
            "type": "String",
            "required": true,
            "optional": false,
            "computed": false,
            "sensitive": false
        },
        "tags": {
            "type": "Map(String)",
            "required": false,
            "optional": true,
            "computed": true,
            "sensitive": false
        }
    },
    "block_types": {
        "subnet": {
            "attributes": {
                "address_prefix": {
                    "type": "String",
                    "required": true,
                    "optional": false,
                    "computed": false,
                    "sensitive": false
                },
                "name": {
                    "type": "String",
                    "required": true,
                    "optional": false,
                    "computed": false,
                    "sensitive": false
                },
                "security_group": {
                    "type": "String",
                    "required": false,
                    "optional": true,
                    "computed": false,
                    "sensitive": false
                }
            },
            "block_types": {},
            "nesting": 3,
            "min_items": 0,
            "max_items": 0
        }
    }
}
```

## after

```
$ make build
$ make install
$ $GOPATH/bin/tfschema resource show -format=json azurerm_virtual_network
{
    "attributes": [
        {
            "name": "address_space",
            "type": "List(String)",
            "required": true,
            "optional": false,
            "computed": false,
            "sensitive": false
        },
        {
            "name": "dns_servers",
            "type": "List(String)",
            "required": false,
            "optional": true,
            "computed": false,
            "sensitive": false
        },
        {
            "name": "location",
            "type": "String",
            "required": true,
            "optional": false,
            "computed": false,
            "sensitive": false
        },
        {
            "name": "name",
            "type": "String",
            "required": true,
            "optional": false,
            "computed": false,
            "sensitive": false
        },
        {
            "name": "resource_group_name",
            "type": "String",
            "required": true,
            "optional": false,
            "computed": false,
            "sensitive": false
        },
        {
            "name": "tags",
            "type": "Map(String)",
            "required": false,
            "optional": true,
            "computed": true,
            "sensitive": false
        }
    ],
    "block_types": [
        {
            "type_name": "subnet",
            "attributes": [
                {
                    "name": "address_prefix",
                    "type": "String",
                    "required": true,
                    "optional": false,
                    "computed": false,
                    "sensitive": false
                },
                {
                    "name": "name",
                    "type": "String",
                    "required": true,
                    "optional": false,
                    "computed": false,
                    "sensitive": false
                },
                {
                    "name": "security_group",
                    "type": "String",
                    "required": false,
                    "optional": true,
                    "computed": false,
                    "sensitive": false
                }
            ],
            "block_types": [],
            "nesting": 3,
            "min_items": 0,
            "max_items": 0
        }
    ]
}
```