### PR TITLE
Use typeexpr.TypeString(cty.Type) in HCL2 instead of our custom logic

### DIFF
--- a/formatter/table/block.go
+++ b/formatter/table/block.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/minamijoyo/tfschema/tfschema"
 	"github.com/olekukonko/tablewriter"
@@ -68,7 +69,7 @@ func renderAttributes(b *Block) (string, error) {
 
 		row := []string{
 			k,
-			typeName,
+			formatTypeName(typeName),
 			strconv.FormatBool(v.Required),
 			strconv.FormatBool(v.Optional),
 			strconv.FormatBool(v.Computed),
@@ -80,6 +81,17 @@ func renderAttributes(b *Block) (string, error) {
 	table.Render()
 
 	return buf.String(), nil
+}
+
+// formatTypeName returns a string formatted type name.
+// If a type name contains object type, its length may be long and it is hard to read.
+// Add a space to the type name so that tablewriter can break it into lines.
+func formatTypeName(name string) string {
+	return strings.Replace(
+		strings.Replace(
+			strings.Replace(name, ",", ", ", -1),
+			"{", "{ ", -1),
+		"}", " }", -1)
 }
 
 // renderBlockTypes returns a formatted string in table format for BlockTypes.

--- a/formatter/table/block.go
+++ b/formatter/table/block.go
@@ -64,10 +64,7 @@ func renderAttributes(b *Block) (string, error) {
 
 	for _, k := range keys {
 		v := b.Attributes[k]
-		typeName, err := v.Type.Name()
-		if err != nil {
-			return "", err
-		}
+		typeName := v.Type.Name()
 
 		row := []string{
 			k,

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/goreleaser/goreleaser v0.106.0
 	github.com/hashicorp/go-hclog v0.0.0-20181001195459-61d530d6c27f
 	github.com/hashicorp/go-plugin v1.0.1-0.20190430211030-5692942914bb
+	github.com/hashicorp/hcl2 v0.0.0-20190515223218-4b22149b7cef
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/terraform v0.12.0
 	github.com/mitchellh/cli v1.0.0

--- a/tfschema/type.go
+++ b/tfschema/type.go
@@ -1,10 +1,7 @@
 package tfschema
 
 import (
-	"fmt"
-	"sort"
-	"strings"
-
+	"github.com/hashicorp/hcl2/ext/typeexpr"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -23,12 +20,7 @@ func NewType(t cty.Type) *Type {
 
 // MarshalJSON returns a encoded string in JSON.
 func (t *Type) MarshalJSON() ([]byte, error) {
-	name, err := t.Name()
-	if err != nil {
-		return nil, err
-	}
-
-	return []byte(`"` + name + `"`), nil
+	return []byte(`"` + t.Name() + `"`), nil
 }
 
 // Name returns a name of type.
@@ -37,94 +29,14 @@ func (t *Type) MarshalJSON() ([]byte, error) {
 // an attribute, it is syntactically NestedBlock but semantically interpreted
 // as an Attribute. In this case, Attribute has a complex data type. It is
 // reasonable to use the same notation as the type annotation in HCL2 to
-// represent the correct data type. However, it seems that HCL2 has a type
-// annotation parser but no writer, so we implement it by ourselves.
+// represent the correct data type.
+// So we use typeexpr.TypeString(cty.Type) in HCL2
 //
 // See also:
 // - https://github.com/minamijoyo/tfschema/issues/9
 // - https://github.com/terraform-providers/terraform-provider-aws/pull/8187
 // - https://github.com/hashicorp/terraform/pull/20626
 // - https://www.terraform.io/docs/configuration/types.html
-func (t *Type) Name() (string, error) {
-	switch {
-	case t.IsPrimitiveType():
-		switch t.Type {
-		case cty.String:
-			return "string", nil
-		case cty.Number:
-			return "number", nil
-		case cty.Bool:
-			return "bool", nil
-		}
-
-	case t.IsListType():
-		elementType := NewType(t.ElementType())
-		elementName, err := elementType.Name()
-		if err != nil {
-			return "", err
-		}
-		return "list(" + elementName + ")", nil
-
-	case t.IsSetType():
-		elementType := NewType(t.ElementType())
-		elementName, err := elementType.Name()
-		if err != nil {
-			return "", err
-		}
-		return "set(" + elementName + ")", nil
-
-	case t.IsMapType():
-		elementType := NewType(t.ElementType())
-		elementName, err := elementType.Name()
-		if err != nil {
-			return "", err
-		}
-		return "map(" + elementName + ")", nil
-
-	case t.IsTupleType():
-		elementTypes := t.TupleElementTypes()
-		elementNames := make([]string, 0, len(elementTypes))
-		for i := range elementTypes {
-			elementType := NewType(t.TupleElementType(i))
-			elementName, err := elementType.Name()
-			if err != nil {
-				return "", err
-			}
-
-			elementNames = append(elementNames, elementName)
-		}
-		return "tuple([ " + strings.Join(elementNames, ", ") + " ])", nil
-	case t.IsObjectType():
-		attributeTypes := t.AttributeTypes()
-		attributeNames := make([]string, 0, len(attributeTypes))
-		for k := range attributeTypes {
-			attributeNames = append(attributeNames, k)
-		}
-		sort.Strings(attributeNames)
-
-		attributes := make([]string, 0, len(attributeTypes))
-		for _, k := range attributeNames {
-			elementType := NewType(t.AttributeType(k))
-			elementName, err := elementType.Name()
-			if err != nil {
-				return "", err
-			}
-
-			attributes = append(attributes, k+"="+elementName)
-		}
-		return "object({ " + strings.Join(attributes, ", ") + " })", nil
-
-	case t.IsCapsuleType():
-		// We notice that there is a capsule type as a cty specification,
-		// but we don't know how to handle it properly,
-		// so we should make an error for now..
-		return "", fmt.Errorf("Failed to get name for unsupported capsule type: %#v", t)
-
-	default:
-		// should never happen
-		return "", fmt.Errorf("Failed to get name for unknown type: %#v", t)
-	}
-
-	// should never happen
-	return "", fmt.Errorf("Failed to get name for type: %#v", t)
+func (t *Type) Name() string {
+	return typeexpr.TypeString(t.Type)
 }


### PR DESCRIPTION
Fixes #18

In #16, I said
> it seems that HCL2 has a type annotation parser but no writer

but it is not true.
I found typeexpr.TypeString(cty.Type) in HCL2 and we should use it.

TypeString returns a string without space.
If a type name contains object type, its length may be long. It’ s hard to read with table mode.
So we add a space to the type name so that tablewriter can break it into lines.

```
[v0.12@use-typeexpr|✔]$ ../../bin/tfschema resource show aws_security_group
+------------------------+--------------------------------+----------+----------+----------+-----------+
| ATTRIBUTE              | TYPE                           | REQUIRED | OPTIONAL | COMPUTED | SENSITIVE |
+------------------------+--------------------------------+----------+----------+----------+-----------+
| arn                    | string                         | false    | false    | true     | false     |
| description            | string                         | false    | true     | false    | false     |
| egress                 | set(object({                   | false    | true     | true     | false     |
|                        | cidr_blocks=list(string),      |          |          |          |           |
|                        | description=string,            |          |          |          |           |
|                        | from_port=number,              |          |          |          |           |
|                        | ipv6_cidr_blocks=list(string), |          |          |          |           |
|                        | prefix_list_ids=list(string),  |          |          |          |           |
|                        | protocol=string,               |          |          |          |           |
|                        | security_groups=set(string),   |          |          |          |           |
|                        | self=bool, to_port=number }))  |          |          |          |           |
| id                     | string                         | false    | true     | true     | false     |
| ingress                | set(object({                   | false    | true     | true     | false     |
|                        | cidr_blocks=list(string),      |          |          |          |           |
|                        | description=string,            |          |          |          |           |
|                        | from_port=number,              |          |          |          |           |
|                        | ipv6_cidr_blocks=list(string), |          |          |          |           |
|                        | prefix_list_ids=list(string),  |          |          |          |           |
|                        | protocol=string,               |          |          |          |           |
|                        | security_groups=set(string),   |          |          |          |           |
|                        | self=bool, to_port=number }))  |          |          |          |           |
| name                   | string                         | false    | true     | true     | false     |
| name_prefix            | string                         | false    | true     | false    | false     |
| owner_id               | string                         | false    | false    | true     | false     |
| revoke_rules_on_delete | bool                           | false    | true     | false    | false     |
| tags                   | map(string)                    | false    | true     | false    | false     |
| vpc_id                 | string                         | false    | true     | true     | false     |
+------------------------+--------------------------------+----------+----------+----------+-----------+

block_type: timeouts, nesting: NestingSingle, min_items: 0, max_items: 0
+-----------+--------+----------+----------+----------+-----------+
| ATTRIBUTE | TYPE   | REQUIRED | OPTIONAL | COMPUTED | SENSITIVE |
+-----------+--------+----------+----------+----------+-----------+
| create    | string | false    | true     | false    | false     |
| delete    | string | false    | true     | false    | false     |
+-----------+--------+----------+----------+----------+-----------+
```