### PR TITLE
Allow custom plugin directories to be specified when using the Go Client

### DIFF
--- a/tfschema/grpc_client.go
+++ b/tfschema/grpc_client.go
@@ -18,9 +18,9 @@ type GRPCClient struct {
 }
 
 // NewGRPCClient creates a new GRPCClient instance.
-func NewGRPCClient(providerName string) (Client, error) {
+func NewGRPCClient(providerName string, pluginDirectories []string) (Client, error) {
 	// find a provider plugin
-	pluginMeta, err := findPlugin("provider", providerName)
+	pluginMeta, err := findPlugin("provider", providerName, pluginDirectories)
 	if err != nil {
 		return nil, err
 	}

--- a/tfschema/netrpc_client.go
+++ b/tfschema/netrpc_client.go
@@ -28,9 +28,9 @@ type NetRPCClient struct {
 }
 
 // NewNetRPCClient creates a new NetRPCClient instance.
-func NewNetRPCClient(providerName string) (Client, error) {
+func NewNetRPCClient(providerName string, pluginDirectories []string) (Client, error) {
 	// find a provider plugin
-	pluginMeta, err := findPlugin("provider", providerName)
+	pluginMeta, err := findPlugin("provider", providerName, pluginDirectories)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When using `tfschema` to be used as a library rather than a CLI tool, it is useful to allow the plugin directory to be specified to allow other tools which enable to target a Terraform working directory, to build upon `tfschema`.  