### PR TITLE
Allow root directory for plugins to be set when using NewClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,15 @@ The tfschema requires the provider's dependency library version to:
 # Rules of finding provider's binary
 When `terraform init` command is executed, provider's binary is installed under the auto installed directory ( .terraform/plugins/`<SOURCE ADDRESS>`/`<VERSION>`/`<OS>_<ARCH>` ) by default.
 The tfschema can use the same provider's binary as terraform uses, so you can run `tfschema` command in the same directory where you run the `terraform` command
-Alternatively, you can set the environment variable `$TFSCHEMA_ROOT_DIRECTORY` to be this directory. If `$TFSCHEMA_ROOT_DIRECTORY` is not set, it will default to the current directory
+Alternatively, you can set the environment variable `$TFSCHEMA_ROOT_DIR` to be this directory. If `$TFSCHEMA_ROOT_DIR` is not set, it will default to the current directory
 
 The tfschema finds provider's binary under the following directories.
 
-1. `$TFSCHEMA_ROOT_DIRECTORY`
+1. `$TFSCHEMA_ROOT_DIR`
 2. same directory as `tfschema` executable
-3. user vendor directory ( `$TFSCHEMA_ROOT_DIRECTORY`/terraform.d/plugins/`<OS>_<ARCH>` )
-4. auto installed directory ( `$TFSCHEMA_ROOT_DIRECTORY`/.terraform/plugins/`<SOURCE ADDRESS>`/`<VERSION>`/`<OS>_<ARCH>` )
-5. legacy auto installed directory ( `$TFSCHEMA_ROOT_DIRECTORY`/.terraform/plugins/`<OS>_<ARCH>` )
+3. user vendor directory ( `$TFSCHEMA_ROOT_DIR`/terraform.d/plugins/`<OS>_<ARCH>` )
+4. auto installed directory ( `$TFSCHEMA_ROOT_DIR`/.terraform/plugins/`<SOURCE ADDRESS>`/`<VERSION>`/`<OS>_<ARCH>` )
+5. legacy auto installed directory ( `$TFSCHEMA_ROOT_DIR`/.terraform/plugins/`<OS>_<ARCH>` )
 6. global plugin directory ( $HOME/.terraform.d/plugins )
 7. global plugin directory with os and arch ( $HOME/.terraform.d/plugins/`<OS>_<ARCH>` )
 8. gopath ( $GOPATH/bin )

--- a/README.md
+++ b/README.md
@@ -92,15 +92,16 @@ The tfschema requires the provider's dependency library version to:
 
 # Rules of finding provider's binary
 When `terraform init` command is executed, provider's binary is installed under the auto installed directory ( .terraform/plugins/`<SOURCE ADDRESS>`/`<VERSION>`/`<OS>_<ARCH>` ) by default.
-The tfschema can use the same provider's binary as terraform uses, so you can run `tfschema` command in the same directory where you run the `terraform` command.
+The tfschema can use the same provider's binary as terraform uses, so you can run `tfschema` command in the same directory where you run the `terraform` command
+Alternatively, you can set the environment variable `$TFSCHEMA_ROOT_DIRECTORY` to be this directory. If `$TFSCHEMA_ROOT_DIRECTORY` is not set, it will default to the current directory
 
 The tfschema finds provider's binary under the following directories.
 
-1. current directory
+1. `$TFSCHEMA_ROOT_DIRECTORY`
 2. same directory as `tfschema` executable
-3. user vendor directory ( terraform.d/plugins/`<OS>_<ARCH>` )
-4. auto installed directory ( .terraform/plugins/`<SOURCE ADDRESS>`/`<VERSION>`/`<OS>_<ARCH>` )
-5. legacy auto installed directory ( .terraform/plugins/`<OS>_<ARCH>` )
+3. user vendor directory ( `$TFSCHEMA_ROOT_DIRECTORY`/terraform.d/plugins/`<OS>_<ARCH>` )
+4. auto installed directory ( `$TFSCHEMA_ROOT_DIRECTORY`/.terraform/plugins/`<SOURCE ADDRESS>`/`<VERSION>`/`<OS>_<ARCH>` )
+5. legacy auto installed directory ( `$TFSCHEMA_ROOT_DIRECTORY`/.terraform/plugins/`<OS>_<ARCH>` )
 6. global plugin directory ( $HOME/.terraform.d/plugins )
 7. global plugin directory with os and arch ( $HOME/.terraform.d/plugins/`<OS>_<ARCH>` )
 8. gopath ( $GOPATH/bin )

--- a/command/autocomplete.go
+++ b/command/autocomplete.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"github.com/minamijoyo/tfschema/tfschema"
 	"github.com/posener/complete"
 )
 
@@ -14,7 +13,7 @@ func (m *Meta) completePredictResourceType() complete.Predictor {
 			return nil
 		}
 
-		client, err := tfschema.NewClient(providerName)
+		client, err := NewDefaultClient(providerName)
 		if err != nil {
 			return nil
 		}
@@ -40,7 +39,7 @@ func (m *Meta) completePredictDataSource() complete.Predictor {
 			return nil
 		}
 
-		client, err := tfschema.NewClient(providerName)
+		client, err := NewDefaultClient(providerName)
 		if err != nil {
 			return nil
 		}

--- a/command/client.go
+++ b/command/client.go
@@ -1,0 +1,19 @@
+package command
+
+import (
+	"github.com/minamijoyo/tfschema/tfschema"
+	"os"
+)
+
+// NewDefaultClient creates a new Client instance.
+func NewDefaultClient(providerName string) (tfschema.Client, error) {
+	rootDir := os.Getenv("TFSCHEMA_ROOT_DIR")
+	if rootDir == "" {
+		rootDir = "."
+	}
+
+	options := tfschema.Option{RootDir: rootDir}
+
+	return tfschema.NewClient(providerName, options)
+}
+

--- a/command/data_list.go
+++ b/command/data_list.go
@@ -2,8 +2,6 @@ package command
 
 import (
 	"strings"
-
-	"github.com/minamijoyo/tfschema/tfschema"
 )
 
 // DataListCommand is a command which lists data sources.
@@ -21,7 +19,7 @@ func (c *DataListCommand) Run(args []string) int {
 
 	providerName := args[0]
 
-	client, err := tfschema.NewClient(providerName)
+	client, err := NewDefaultClient(providerName)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/command/data_show.go
+++ b/command/data_show.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"strings"
 
-	"github.com/minamijoyo/tfschema/tfschema"
 	"github.com/posener/complete"
 )
 
@@ -36,7 +35,7 @@ func (c *DataShowCommand) Run(args []string) int {
 		return 1
 	}
 
-	client, err := tfschema.NewClient(providerName)
+	client, err := NewDefaultClient(providerName)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/command/provider_show.go
+++ b/command/provider_show.go
@@ -3,8 +3,6 @@ package command
 import (
 	"flag"
 	"strings"
-
-	"github.com/minamijoyo/tfschema/tfschema"
 )
 
 // ProviderShowCommand is a command which shows a type definition of provider.
@@ -30,7 +28,7 @@ func (c *ProviderShowCommand) Run(args []string) int {
 
 	providerName := cmdFlags.Args()[0]
 
-	client, err := tfschema.NewClient(providerName)
+	client, err := NewDefaultClient(providerName)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/command/resource_list.go
+++ b/command/resource_list.go
@@ -2,8 +2,6 @@ package command
 
 import (
 	"strings"
-
-	"github.com/minamijoyo/tfschema/tfschema"
 )
 
 // ResourceListCommand is a command which lists resource types.
@@ -21,7 +19,7 @@ func (c *ResourceListCommand) Run(args []string) int {
 
 	providerName := args[0]
 
-	client, err := tfschema.NewClient(providerName)
+	client, err := NewDefaultClient(providerName)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/command/resource_show.go
+++ b/command/resource_show.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"strings"
 
-	"github.com/minamijoyo/tfschema/tfschema"
 	"github.com/posener/complete"
 )
 
@@ -36,7 +35,7 @@ func (c *ResourceShowCommand) Run(args []string) int {
 		return 1
 	}
 
-	client, err := tfschema.NewClient(providerName)
+	client, err := NewDefaultClient(providerName)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/tfschema/client.go
+++ b/tfschema/client.go
@@ -90,8 +90,13 @@ func findPlugin(pluginType string, pluginName string) (*discovery.PluginMeta, er
 func pluginDirs() ([]string, error) {
 	dirs := []string{}
 
+	rootDirectory := os.Getenv("TFSCHEMA_ROOT_DIRECTORY")
+	if rootDirectory == "" {
+		rootDirectory = "."
+	}
+
 	// current directory
-	dirs = append(dirs, ".")
+	dirs = append(dirs, rootDirectory)
 
 	// same directory as this executable (not terraform)
 	exePath, err := os.Executable()
@@ -104,7 +109,7 @@ func pluginDirs() ([]string, error) {
 	// For Terraform v0.13, it is still supported but considered as legacy
 	// because now we can download third-party providers from Terraform Registry.
 	arch := runtime.GOOS + "_" + runtime.GOARCH
-	vendorDir := filepath.Join("terraform.d", "plugins", arch)
+	vendorDir := filepath.Join(rootDirectory, "terraform.d", "plugins", arch)
 	dirs = append(dirs, vendorDir)
 
 	// auto installed directory for Terraform v0.13+
@@ -118,7 +123,7 @@ func pluginDirs() ([]string, error) {
 	// but even if it is configured, the selection file is stored under
 	// .terraform/plugins directory and provider binaries are symlinked to the
 	// cache directory when running terraform init.
-	autoInstalledDirs, err := newSelectionFile(filepath.Join(".terraform", "plugins", "selections.json")).pluginDirs()
+	autoInstalledDirs, err := newSelectionFile(filepath.Join(rootDirectory, ".terraform", "plugins", "selections.json")).pluginDirs()
 	if err != nil {
 		return []string{}, err
 	}
@@ -126,7 +131,7 @@ func pluginDirs() ([]string, error) {
 	dirs = append(dirs, autoInstalledDirs...)
 
 	// auto installed directory for Terraform < v0.13
-	legacyAutoInstalledDir := filepath.Join(".terraform", "plugins", arch)
+	legacyAutoInstalledDir := filepath.Join(rootDirectory, ".terraform", "plugins", arch)
 	dirs = append(dirs, legacyAutoInstalledDir)
 
 	// global plugin directory

--- a/tfschema/client.go
+++ b/tfschema/client.go
@@ -37,11 +37,16 @@ type Client interface {
 	Close()
 }
 
+// Option is an options struct for extra options for NewClient
+type Option struct {
+	RootDir string
+}
+
 // NewClient creates a new Client instance.
-func NewClient(providerName string) (Client, error) {
+func NewClient(providerName string, options Option) (Client, error) {
 	// First, try to connect by GRPC protocol (version 5)
 	log.Println("[DEBUG] try to connect by GRPC protocol (version 5)")
-	client, err := NewGRPCClient(providerName)
+	client, err := NewGRPCClient(providerName, options)
 	if err == nil {
 		return client, nil
 	}
@@ -52,7 +57,7 @@ func NewClient(providerName string) (Client, error) {
 	// We guess it is for Terraform v0.11 to connect to the latest provider.
 	// So we implement our own fallback logic here.
 	log.Println("[DEBUG] try to connect by NetRPC protocol (version 4)")
-	client, err = NewNetRPCClient(providerName)
+	client, err = NewNetRPCClient(providerName, options)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to NewClient: %s", err)
 	}
@@ -61,8 +66,8 @@ func NewClient(providerName string) (Client, error) {
 }
 
 // findPlugin finds a plugin with the name specified in the arguments.
-func findPlugin(pluginType string, pluginName string) (*discovery.PluginMeta, error) {
-	dirs, err := pluginDirs()
+func findPlugin(pluginType string, pluginName string, rootDir string) (*discovery.PluginMeta, error) {
+	dirs, err := pluginDirs(rootDir)
 	if err != nil {
 		return nil, err
 	}
@@ -87,16 +92,11 @@ func findPlugin(pluginType string, pluginName string) (*discovery.PluginMeta, er
 // - Can't import internal packages of Terraform and it's too complicated to support
 // - For debug
 // For more details, read inline comments.
-func pluginDirs() ([]string, error) {
+func pluginDirs(rootDir string) ([]string, error) {
 	dirs := []string{}
 
-	rootDirectory := os.Getenv("TFSCHEMA_ROOT_DIR")
-	if rootDirectory == "" {
-		rootDirectory = "."
-	}
-
 	// current directory
-	dirs = append(dirs, rootDirectory)
+	dirs = append(dirs, rootDir)
 
 	// same directory as this executable (not terraform)
 	exePath, err := os.Executable()
@@ -109,7 +109,7 @@ func pluginDirs() ([]string, error) {
 	// For Terraform v0.13, it is still supported but considered as legacy
 	// because now we can download third-party providers from Terraform Registry.
 	arch := runtime.GOOS + "_" + runtime.GOARCH
-	vendorDir := filepath.Join(rootDirectory, "terraform.d", "plugins", arch)
+	vendorDir := filepath.Join(rootDir, "terraform.d", "plugins", arch)
 	dirs = append(dirs, vendorDir)
 
 	// auto installed directory for Terraform v0.13+
@@ -123,7 +123,7 @@ func pluginDirs() ([]string, error) {
 	// but even if it is configured, the selection file is stored under
 	// .terraform/plugins directory and provider binaries are symlinked to the
 	// cache directory when running terraform init.
-	autoInstalledDirs, err := newSelectionFile(filepath.Join(rootDirectory, ".terraform", "plugins", "selections.json")).pluginDirs()
+	autoInstalledDirs, err := newSelectionFile(filepath.Join(rootDir, ".terraform", "plugins", "selections.json")).pluginDirs()
 	if err != nil {
 		return []string{}, err
 	}
@@ -131,7 +131,7 @@ func pluginDirs() ([]string, error) {
 	dirs = append(dirs, autoInstalledDirs...)
 
 	// auto installed directory for Terraform < v0.13
-	legacyAutoInstalledDir := filepath.Join(rootDirectory, ".terraform", "plugins", arch)
+	legacyAutoInstalledDir := filepath.Join(rootDir, ".terraform", "plugins", arch)
 	dirs = append(dirs, legacyAutoInstalledDir)
 
 	// global plugin directory

--- a/tfschema/client.go
+++ b/tfschema/client.go
@@ -90,7 +90,7 @@ func findPlugin(pluginType string, pluginName string) (*discovery.PluginMeta, er
 func pluginDirs() ([]string, error) {
 	dirs := []string{}
 
-	rootDirectory := os.Getenv("TFSCHEMA_ROOT_DIRECTORY")
+	rootDirectory := os.Getenv("TFSCHEMA_ROOT_DIR")
 	if rootDirectory == "" {
 		rootDirectory = "."
 	}

--- a/tfschema/grpc_client.go
+++ b/tfschema/grpc_client.go
@@ -18,9 +18,9 @@ type GRPCClient struct {
 }
 
 // NewGRPCClient creates a new GRPCClient instance.
-func NewGRPCClient(providerName string) (Client, error) {
+func NewGRPCClient(providerName string, options Option) (Client, error) {
 	// find a provider plugin
-	pluginMeta, err := findPlugin("provider", providerName)
+	pluginMeta, err := findPlugin("provider", providerName, options.RootDir)
 	if err != nil {
 		return nil, err
 	}

--- a/tfschema/netrpc_client.go
+++ b/tfschema/netrpc_client.go
@@ -28,9 +28,9 @@ type NetRPCClient struct {
 }
 
 // NewNetRPCClient creates a new NetRPCClient instance.
-func NewNetRPCClient(providerName string) (Client, error) {
+func NewNetRPCClient(providerName string, options Option) (Client, error) {
 	// find a provider plugin
-	pluginMeta, err := findPlugin("provider", providerName)
+	pluginMeta, err := findPlugin("provider", providerName, options.RootDir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When using `tfschema` as a library rather than a CLI tool, some plugin directories are relative to the project's root directory. It would be useful to allow users of the library to pass the Terraform working directory

Should close #22 