### PR TITLE
Added NewClient option to override logger

### DIFF
--- a/tfschema/client.go
+++ b/tfschema/client.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform/plugin/discovery"
 	"github.com/mitchellh/go-homedir"
 )
@@ -40,6 +41,7 @@ type Client interface {
 // Option is an options struct for extra options for NewClient
 type Option struct {
 	RootDir string
+	Logger  hclog.Logger
 }
 
 // NewClient creates a new Client instance.

--- a/tfschema/grpc_client.go
+++ b/tfschema/grpc_client.go
@@ -27,6 +27,9 @@ func NewGRPCClient(providerName string, options Option) (Client, error) {
 
 	// create a plugin client config
 	config := newGRPCClientConfig(pluginMeta)
+	if options.Logger != nil {
+		config.Logger = options.Logger
+	}
 
 	// initialize a plugin client.
 	pluginClient := plugin.NewClient(config)

--- a/tfschema/netrpc_client.go
+++ b/tfschema/netrpc_client.go
@@ -37,6 +37,9 @@ func NewNetRPCClient(providerName string, options Option) (Client, error) {
 
 	// create a plugin client config
 	config := newNetRPCClientConfig(pluginMeta)
+	if options.Logger != nil {
+		config.Logger = options.Logger
+	}
 
 	// initialize a plugin client.
 	pluginClient := plugin.NewClient(config)


### PR DESCRIPTION
github.com/env0/terratag is using tfschema not as a subprocess, but by calling public API. currently, public API creates hcl.Logger with output set directly to os.Stderr with log level being TRACE. this means terratag output always contains a lot of debug info, less relevant for terratag users. we wanted to be able to control the logger, both output and log level, so we added that as an option to NewClient public function.