### PR TITLE
added -provider cli flag for tfschema show

### DIFF
--- a/tfschema/client.go
+++ b/tfschema/client.go
@@ -83,7 +83,7 @@ func findPlugin(pluginType string, pluginName string, rootDir string) (*discover
 		return &ret, nil
 	}
 
-	return nil, fmt.Errorf("Failed to find plugin: %s. Plugin binary was not found in any of the following directories: [%s]", pluginName, strings.Join(dirs, ", "))
+	return nil, fmt.Errorf("Failed to find plugin: %s. Plugin binary was not found in any of the following directories: [%s] (in some cases you might need to specify -provider=<name>, e.g. provider name google-beta for google_* resources)", pluginName, strings.Join(dirs, ", "))
 }
 
 // pluginDirs returns a list of directories to find plugin.


### PR DESCRIPTION
referencing https://github.com/env0/terratag/issues/17

look at the example below: `google_billing_budget` resource
comes from `google-beta` provider. previously, code assumed
the provider name is the first part by underscore, e.g., `google`.

```
data "google_billing_account" "account" {
  provider = google-beta
  billing_account = "000000-0000000-0000000-000000"
}

resource "google_billing_budget" "budget" {
  provider = google-beta
  billing_account = data.google_billing_account.account.id
  display_name = "Example Billing Budget"

  budget_filter {
    projects = ["projects/my-project-name"]
    credit_types_treatment = "EXCLUDE_ALL_CREDITS"
    services = ["services/24E6-581D-38E5"] # Bigquery
  }

  amount {
    specified_amount {
      currency_code = "USD"
      units = "100000"
    }
  }

  threshold_rules {
    threshold_percent = 0.5
  }
  threshold_rules {
    threshold_percent = 0.9
    spend_basis = "FORECASTED_SPEND"
  }
}
```