### PR TITLE
Fixed broken links from 'tfschema resource browse <resource>'

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -9,7 +9,8 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-const docBaseURL = "https://www.terraform.io/docs/providers/"
+const docBaseURL = "https://registry.terraform.io/providers/hashicorp/"
+const latestDocs = "/latest/docs"
 
 // Meta are the meta-options that are available on all or most commands.
 type Meta struct {
@@ -27,8 +28,8 @@ func detectProviderName(name string) (string, error) {
 
 func buildProviderDocURL(providerName string) (string, error) {
 	// build a doc URL like this
-	// https://www.terraform.io/docs/providers/aws/index.html
-	url := docBaseURL + providerName + "/index.html"
+	// https://registry.terraform.io/providers/hashicorp/aws/latest/docs
+	url := docBaseURL + providerName + latestDocs
 	return url, nil
 }
 
@@ -39,8 +40,8 @@ func buildResourceDocURL(resourceType string) (string, error) {
 	}
 
 	// build a doc URL like this
-	// https://www.terraform.io/docs/providers/aws/r/security_group.html
-	url := docBaseURL + s[0] + "/r/" + s[1] + ".html"
+	// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group
+	url := docBaseURL + s[0] + latestDocs + "/resources/" + s[1]
 	return url, nil
 }
 
@@ -51,8 +52,8 @@ func buildDataDocURL(dataSource string) (string, error) {
 	}
 
 	// build a doc URL like this
-	// https://www.terraform.io/docs/providers/aws/d/security_group.html
-	url := docBaseURL + s[0] + "/d/" + s[1] + ".html"
+	// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group
+	url := docBaseURL + s[0] + latestDocs + "/data-sources/" + s[1]
 	return url, nil
 }
 

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -51,7 +51,7 @@ func TestBuildProviderDocURL(t *testing.T) {
 		{
 			desc: "simple",
 			name: "aws",
-			want: "https://www.terraform.io/docs/providers/aws/index.html",
+			want: "https://registry.terraform.io/providers/hashicorp/aws/latest/docs",
 			ok:   true,
 		},
 	}
@@ -84,7 +84,7 @@ func TestBuildResourceDocURL(t *testing.T) {
 		{
 			desc: "simple",
 			name: "aws_security_group",
-			want: "https://www.terraform.io/docs/providers/aws/r/security_group.html",
+			want: "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group",
 			ok:   true,
 		},
 		{
@@ -123,7 +123,7 @@ func TestBuildDataDocURL(t *testing.T) {
 		{
 			desc: "simple",
 			name: "aws_security_group",
-			want: "https://www.terraform.io/docs/providers/aws/d/security_group.html",
+			want: "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group",
 			ok:   true,
 		},
 		{


### PR DESCRIPTION
See https://github.com/minamijoyo/tfschema/issues/37

The links generated by `tfschema resource browse <resource>` and `tfschema data browse <data>` are no longer working. For the links to work, I've removed the `.html` from the end of the URLs. I also changed the link formatting to what Terraform Registry is actually using (no longer requires a redirect).

I don't know the exact root cause of the links no longer working, but my guess is that Hashicorp has stopped the support of legacy naming for provider docs - https://www.terraform.io/registry/providers/docs#migrating-legacy-providers-docs
```
If you want to publish docs on the Terraform Registry that are not currently published to terraform.io, take the following steps to migrate to the newer format:

    1. Move the website/docs/ folder to docs/
    2. Expand the folder names to match the Terraform Registry's expected format:
        - Rename docs/d/ to docs/data-sources/
        - Rename docs/r/ to docs/resources/
    3. Change file suffixes from .html.markdown or .html.md to .md.
```