### PR TITLE
Fix URLs generated for non-Hashicorp providers

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -9,8 +9,7 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-const docBaseURL = "https://registry.terraform.io/providers/hashicorp/"
-const latestDocs = "/latest/docs"
+const docBaseURL = "https://www.terraform.io/docs/providers/"
 
 // Meta are the meta-options that are available on all or most commands.
 type Meta struct {
@@ -28,8 +27,8 @@ func detectProviderName(name string) (string, error) {
 
 func buildProviderDocURL(providerName string) (string, error) {
 	// build a doc URL like this
-	// https://registry.terraform.io/providers/hashicorp/aws/latest/docs
-	url := docBaseURL + providerName + latestDocs
+	// https://www.terraform.io/docs/providers/aws/index.html
+	url := docBaseURL + providerName + "/index.html"
 	return url, nil
 }
 
@@ -40,8 +39,8 @@ func buildResourceDocURL(resourceType string) (string, error) {
 	}
 
 	// build a doc URL like this
-	// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group
-	url := docBaseURL + s[0] + latestDocs + "/resources/" + s[1]
+	// https://www.terraform.io/docs/providers/aws/r/security_group
+	url := docBaseURL + s[0] + "/r/" + s[1]
 	return url, nil
 }
 
@@ -52,8 +51,8 @@ func buildDataDocURL(dataSource string) (string, error) {
 	}
 
 	// build a doc URL like this
-	// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group
-	url := docBaseURL + s[0] + latestDocs + "/data-sources/" + s[1]
+	// https://www.terraform.io/docs/providers/aws/d/security_group
+	url := docBaseURL + s[0] + "/d/" + s[1]
 	return url, nil
 }
 

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -51,7 +51,7 @@ func TestBuildProviderDocURL(t *testing.T) {
 		{
 			desc: "simple",
 			name: "aws",
-			want: "https://registry.terraform.io/providers/hashicorp/aws/latest/docs",
+			want: "https://www.terraform.io/docs/providers/aws/index.html",
 			ok:   true,
 		},
 	}
@@ -84,7 +84,7 @@ func TestBuildResourceDocURL(t *testing.T) {
 		{
 			desc: "simple",
 			name: "aws_security_group",
-			want: "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group",
+			want: "https://www.terraform.io/docs/providers/aws/r/security_group",
 			ok:   true,
 		},
 		{
@@ -123,7 +123,7 @@ func TestBuildDataDocURL(t *testing.T) {
 		{
 			desc: "simple",
 			name: "aws_security_group",
-			want: "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group",
+			want: "https://www.terraform.io/docs/providers/aws/d/security_group",
 			ok:   true,
 		},
 		{


### PR DESCRIPTION
Previous fix (0.7.2) for Resource/Data Doc URLs didn't work for non-Hashicorp providers. Hashicorp providers, like AWS, Azure, Kubernetes are now working but the non-Hashicorp URLs generated from `tfschema resource/data provider <name>` are going to a 404 page.

Example:

```
tfschema resource browse okta_group
```
Creates the link: `https://registry.terraform.io/providers/hashicorp/okta/latest/docs/resources/group`
The correct link: `https://registry.terraform.io/providers/okta/okta/latest/docs/resources/group`

Note that the URL should be using `/providers/okta/okta/` and not `/providers/hashicorp/okta/`.

This PR reverts the `docBaseURL` constant and `buildXDocURL` functions to their previous format but with the `.html` suffix removed for Data and Resource URLs.


Verify that the following are working:
```
tfschema resource browse okta_group
tfschema data browse okta_group

tfschema resource browse aws_security_group
tfschema data browse aws_security_group
```