### PR TITLE
Update golangci-lint to v1.45.2 and actions to latest

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,8 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v2
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
-        version: v1.43.0
+        go-version: 1.16.2
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.45.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,11 +13,11 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.16
     - name: Run GoReleaser

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,11 +20,11 @@ jobs:
         - ubuntu-latest
         - macOS-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
         go-version: '1.16.2'
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -46,7 +46,7 @@ jobs:
     env:
       TERRAFORM_VERSION: ${{ matrix.terraform }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: docker build
       run: docker-compose build
     - name: terraform --version


### PR DESCRIPTION
The golangci/golangci-lint-action@v2 implicitly installs Go and its version was recently upgraded to Go 1.18. It causes an issue for old golangci-lint. To fix the problem either upgrading golangci-lint-action@v3 and setup Go 1.16.x explicitly or updating golangci-lint to the latest v1.45.2. I fixed both and also upgrading some actions to the latest.