### PR TITLE
Add OpenTofu to test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
         go-version-file: '.go-version'
     - name: test
       run: make test
-  testacc:
+  testacc_terraform:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -39,11 +39,31 @@ jobs:
         - 0.12.31
     env:
       TERRAFORM_VERSION: ${{ matrix.terraform }}
+      TFSCHEMA_TF_MODE: terraform
     steps:
     - uses: actions/checkout@v3
     - name: docker build
       run: docker-compose build
     - name: terraform --version
       run: docker-compose run --rm tfschema terraform --version
+    - name: testacc
+      run: docker-compose run --rm tfschema make testacc
+  testacc_opentofu:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        opentofu:
+        - 1.6.0-alpha3
+    env:
+      OPENTOFU_VERSION: ${{ matrix.opentofu }}
+      TFSCHEMA_TF_MODE: opentofu
+    steps:
+    - uses: actions/checkout@v3
+    - name: docker build
+      run: docker-compose build
+    - name: opentofu --version
+      run: |
+        docker-compose run --rm tfschema tofu --version
     - name: testacc
       run: docker-compose run --rm tfschema make testacc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 ARG TERRAFORM_VERSION=latest
+ARG OPENTOFU_VERSION=latest
+
 FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform
+FROM ghcr.io/opentofu/opentofu:$OPENTOFU_VERSION AS opentofu
 
 FROM golang:1.21-alpine3.18
 RUN apk --no-cache add make git bash
@@ -12,6 +15,7 @@ RUN apk --no-cache add make git bash
 RUN git config --global --add safe.directory /work
 
 COPY --from=terraform /bin/terraform /usr/local/bin/
+COPY --from=opentofu /usr/local/bin/tofu /usr/local/bin/
 WORKDIR /work
 
 COPY go.mod go.sum ./

--- a/command/test_helper.go
+++ b/command/test_helper.go
@@ -58,10 +58,20 @@ func setupTestAcc(t *testing.T, providerName string, providerVersion string) {
 	})
 
 	// terraform init
-	cmd := exec.Command("terraform", "init")
+	terraformExecPath := ""
+	tfMode := os.Getenv("TFSCHEMA_TF_MODE")
+	switch tfMode {
+	case "terraform":
+		terraformExecPath = "terraform"
+	case "opentofu":
+		terraformExecPath = "tofu"
+	default:
+		t.Fatalf("unknown TFSCHEMA_TF_MODE: %s", tfMode)
+	}
+	cmd := exec.Command(terraformExecPath, "init")
 	cmd.Dir = workDir
 	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("failed to run terraform init: %s, out: %s", err, out)
+		t.Fatalf("failed to run %s init: %s, out: %s", terraformExecPath, err, out)
 	}
 
 	// check if the workDir was initizalied.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,11 @@ services:
       context: .
       args:
         TERRAFORM_VERSION: ${TERRAFORM_VERSION:-latest}
+        OPENTOFU_VERSION: ${OPENTOFU_VERSION:-latest}
     volumes:
       - ".:/work"
     environment:
+      TFSCHEMA_TF_MODE: ${TFSCHEMA_TF_MODE:-terraform}
       CGO_ENABLED: 0 # disable cgo for go test
       # Use the same filesystem to avoid a checksum mismatch error
       # or a file busy error caused by asynchronous IO.


### PR DESCRIPTION
Part of #50.

OpenTofu, a community fork of Terraform, has yet to be released as stable, but an alpha version is available. Let's add it to the test matrix.
A new environment variable, TFSCHEMA_TF_MODE, is required only for testing, not runtime.