### PR TITLE
Disable CGO

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    env:
+      - CGO_ENABLED=0
 release:
   prerelease: auto
 changelog:


### PR DESCRIPTION
Fixes #53

Starting from Go 1.20, we need to set CGO_ENABLED=0 explicitly.