### PR TITLE
Add support for OpenTofu v1.6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         opentofu:
-        - 1.6.0-alpha3
+        - 1.6.0
     env:
       OPENTOFU_VERSION: ${{ matrix.opentofu }}
       TFSCHEMA_TF_MODE: opentofu

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ brews:
       name: "Masayuki Morita"
       email: minamijoyo@gmail.com
     homepage: https://github.com/minamijoyo/tfschema
-    description: "A schema inspector for Terraform providers."
+    description: "A schema inspector for Terraform / OpenTofu providers."
     skip_upload: auto
     test: |
       system "#{bin}/tfschema --version"

--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@
 [![GitHub release](https://img.shields.io/github/release/minamijoyo/tfschema.svg)](https://github.com/minamijoyo/tfschema/releases/latest)
 [![GoDoc](https://godoc.org/github.com/minamijoyo/tfschema/tfschema?status.svg)](https://godoc.org/github.com/minamijoyo/tfschema)
 
-A schema inspector for Terraform providers.
+A schema inspector for Terraform / OpenTofu providers.
 
 # Features
 
-- Get resource type definitions dynamically from Terraform providers via go-plugin protocol.
+- Get resource type definitions dynamically from Terraform / OpenTofu providers via go-plugin protocol.
 - List available resource types.
 - Autocomplete resource types in bash/zsh.
 - Open official provider documents quickly by your system web browser.
-- Terraform v0.15 support (minimum requirements: Terraform >= v0.12)
+- Terraform v0.15+ support (minimum requirements: Terraform >= v0.12)
+- OpenTofu v1.6+ support
 
 ![demo](/images/tfschema-demo.gif)
 


### PR DESCRIPTION
Most of the work on OpenTofu support has already been done in #52. The last piece is running CI on the GA version and clarifying in the description that OpenTofu is supported.