### PR TITLE
Add support for OpenTofu v1.11

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,8 +52,8 @@ jobs:
     strategy:
       matrix:
         opentofu:
-        - 1.8.0
-        - 1.7.3
+        - 1.11.6
+        - 1.10.9
         - 1.6.3
     env:
       OPENTOFU_VERSION: ${{ matrix.opentofu }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 ARG TERRAFORM_VERSION=latest
-ARG OPENTOFU_VERSION=latest
-
 FROM hashicorp/terraform:$TERRAFORM_VERSION AS terraform
-FROM ghcr.io/opentofu/opentofu:$OPENTOFU_VERSION AS opentofu
+
+FROM alpine:3.20 AS opentofu
+ARG OPENTOFU_VERSION=latest
+ADD https://get.opentofu.org/install-opentofu.sh /install-opentofu.sh
+RUN chmod +x /install-opentofu.sh
+RUN apk add gpg gpg-agent
+RUN ./install-opentofu.sh --install-method standalone --opentofu-version $OPENTOFU_VERSION --install-path /usr/local/bin --symlink-path -
 
 FROM golang:1.22-alpine3.20
 RUN apk --no-cache add make git bash


### PR DESCRIPTION
Starting with OpenTofu v1.9, official Docker images are deprecated. It is recommended to use the official installer instead.